### PR TITLE
Ingress URL returns to frontend when ready

### DIFF
--- a/app/src/components/nodes/DockerNode.jsx
+++ b/app/src/components/nodes/DockerNode.jsx
@@ -101,7 +101,9 @@ export default function ({ id, data, isConnectable }) {
         yaml: yaml,
       }),
     })
-      .then(() => {
+      .then((res) => res.json())
+      .then((ingressUrl) => {
+        // TODO: put this ingressUrl into the state
         dispatch(updateNode({ id, data: { status: 'running' } }));
         const edges = state.edges.filter((edge) => edge.source === id);
         edges.map((edge) =>

--- a/app/src/components/nodes/GithubNode.jsx
+++ b/app/src/components/nodes/GithubNode.jsx
@@ -162,7 +162,9 @@ export default function ({ id, data, isConnectable }) {
         yaml: yaml,
       }),
     })
-      .then(() => {
+      .then((res) => res.json())
+      .then((ingressUrl) => {
+        // TODO: put this ingressUrl into the state
         console.log('should change status');
         dispatch(updateNode({ id, data: { status: 'running' } }));
         const edges = state.edges.filter((edge) => edge.source === id);

--- a/server/controllers/deploymentController.js
+++ b/server/controllers/deploymentController.js
@@ -244,9 +244,22 @@ deploymentController.getURL = (req, res, next) => {
 
   k8.connectCLtoAWS(awsAccessKey, awsSecretKey, vpcRegion);
   k8.connectKubectltoEKS = (vpcRegion, clusterName);
-  const address = k8.getURL();
-  res.locals.address = address;
-  return next();
+
+  // This function will keep calling itself until the address exists.
+  // Once it does, it will put it on res.locals and call next();
+  const checkURL = () => {
+    console.log('Checking...');
+    const address = k8.getUrl();
+    console.log('Address:', address);
+    if (address) {
+      res.locals.address = address;
+      return next();
+    } else {
+      setTimeout(checkURL, 100);
+    }
+  };
+
+  checkURL();
 };
 
 module.exports = deploymentController;

--- a/server/kubernetes/kubernetesapi.js
+++ b/server/kubernetes/kubernetesapi.js
@@ -39,12 +39,18 @@ const remove = (kind, name) => {
 };
 
 // get the public ingress url
+// This will return an empty string if there is an ingress but the url is not ready yet
+// This will return 'no ingress attached' if this cluster doesn't have an ingress
 const getUrl = () => {
-  const output = execSync(
-    `kubectl get ingress -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'`,
-    { encoding: 'utf8' }
-  );
-  return output;
+  try {
+    const output = execSync(
+      `kubectl get ingress -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'`,
+      { encoding: 'utf8' }
+    );
+    return output;
+  } catch (err) {
+    return 'no ingress attached';
+  }
 };
 
 module.exports = {

--- a/server/routes/deployment.js
+++ b/server/routes/deployment.js
@@ -14,13 +14,22 @@ router.post('/addCluster', deploymentController.addCluster, (req, res) => {
   res.status(200).json(res.locals.data);
 });
 
-router.post('/deleteCluster', deploymentController.deleteCluster, (req, res) => {
-  res.sendStatus(200);
-});
+router.post(
+  '/deleteCluster',
+  deploymentController.deleteCluster,
+  (req, res) => {
+    res.sendStatus(200);
+  }
+);
 
-router.post('/configureCluster', deploymentController.configureCluster, (req, res) => {
-  res.sendStatus(200);
-});
+router.post(
+  '/configureCluster',
+  deploymentController.configureCluster,
+  deploymentController.getURL,
+  (req, res) => {
+    res.status(200).json(res.locals.address);
+  }
+);
 
 router.post('/build', deploymentController.build, (req, res) => {
   res.status(200).json(res.locals.data);
@@ -28,10 +37,6 @@ router.post('/build', deploymentController.build, (req, res) => {
 
 router.post('/destroyImage', deploymentController.destroyImage, (req, res) => {
   res.sendStatus(200);
-});
-
-router.post('/getURL', deploymentController.getURL, (req, res) => {
-  res.status(200).json(res.locals.address);
 });
 
 module.exports = router;


### PR DESCRIPTION
This commit has is so that when the frontend fetches /configureCluster from DockerNode.jsx or GithubNode.jsx the server will wait to return a response until the ingress url has been assigned. That response will contain the url. 

I have updated the frontend to receive that url, **but it's not currently doing anything with it**. I'm not clear on where in the state it should go. 

Also, if there is no ingress in the cluster, the string 'no ingress attached' will be returned.